### PR TITLE
fix: remove outputs from management cloudformation stack to ignore terraform warning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,6 @@ resource "aws_cloudformation_stack" "management" {
   lifecycle {
     ignore_changes = [
       capabilities,
-      outputs,
     ]
   }
 }


### PR DESCRIPTION
Gets rid of this warning:

```
Warning: Redundant ignore_changes element
  on .terraform/modules/cloudaccess_lza.default_boundary/main.tf line 42, in resource "aws_cloudformation_stack" "management":
  42: resource "aws_cloudformation_stack" "management" {
Adding an attribute name to ignore_changes tells Terraform to ignore future
changes to the argument in configuration after the object has been created,
retaining the value originally configured.
The attribute outputs is decided by the provider alone and therefore there
can be no configured value to compare with. Including this attribute in
ignore_changes has no effect. Remove the attribute from ignore_changes to
quiet this warning.
```