### PR TITLE
chore: add pinDigests for github-actions manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ module "boundary" {
   description               = "Used to deploy the default permissions boundary for the pipelines."
   enable_management_account = true
   name                      = "LZA-IAM-DefaultBoundary"
-  region                    = "us-west-2"
   tags                      = {}
   template                  = file("assets/default-boundary.yml")
   parameters                = {}
@@ -76,7 +75,6 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_description"></a> [description](#input\_description) | The description of the cloudformation stack | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | The name of the cloudformation stack | `string` | n/a | yes |
-| <a name="input_region"></a> [region](#input\_region) | The region to deploy the cloudformation template | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | The tags to apply to the cloudformation stack | `map(string)` | n/a | yes |
 | <a name="input_template"></a> [template](#input\_template) | The body of the cloudformation template to deploy | `string` | n/a | yes |
 | <a name="input_capabilities"></a> [capabilities](#input\_capabilities) | The capabilities required to deploy the cloudformation template | `list(string)` | <pre>[<br/>  "CAPABILITY_NAMED_IAM",<br/>  "CAPABILITY_AUTO_EXPAND",<br/>  "CAPABILITY_IAM"<br/>]</pre> | no |

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_description"></a> [description](#input\_description) | The description of the cloudformation stack | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | The name of the cloudformation stack | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The region to deploy the cloudformation template | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | The tags to apply to the cloudformation stack | `map(string)` | n/a | yes |
 | <a name="input_template"></a> [template](#input\_template) | The body of the cloudformation template to deploy | `string` | n/a | yes |
 | <a name="input_capabilities"></a> [capabilities](#input\_capabilities) | The capabilities required to deploy the cloudformation template | `list(string)` | <pre>[<br/>  "CAPABILITY_NAMED_IAM",<br/>  "CAPABILITY_AUTO_EXPAND",<br/>  "CAPABILITY_IAM"<br/>]</pre> | no |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -13,6 +13,8 @@ module "boundary" {
   enable_management_account = true
   ## The name of the cloudformation stack 
   name = "LZA-IAM-DefaultBoundary-Sandbox"
+  ## The region to deploy the cloudformation template
+  region = "us-west-2"
   ## The tags to apply to the cloudformation stack
   tags = {}
   ## The cloudformation template to deploy
@@ -32,6 +34,8 @@ module "boundary_by_organization" {
   enable_management_account = true
   ## The name of the cloudformation stack
   name = "LZA-IAM-DefaultBoundary-Sandbox"
+  ## The region to deploy the cloudformation template
+  region = "us-west-2"
   ## The tags to apply to the cloudformation stack
   tags = {}
   ## The cloudformation template to deploy 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -13,30 +13,26 @@ module "boundary" {
   enable_management_account = true
   ## The name of the cloudformation stack 
   name = "LZA-IAM-DefaultBoundary-Sandbox"
-  ## The region to deploy the cloudformation template
-  region = "us-west-2"
-  ## The tags to apply to the cloudformation stack 
+  ## The tags to apply to the cloudformation stack
   tags = {}
-  ## The cloudformation template to deploy 
+  ## The cloudformation template to deploy
   template = file("assets/default-boundary.yml")
   ## Parameters passed to the cloudformation template
   parameters = {}
   ## Optional list of organization units to deploy the boundary, else defaults to all organization units
 }
 
-## Deploy the boundary to a specific organization unit 
+## Deploy the boundary to a specific organization unit
 module "boundary_by_organization" {
   source = "../.."
 
-  ## The description of the cloudformation stack 
+  ## The description of the cloudformation stack
   description = "Used to deploy the default permissions boundary for the pipelines."
   ## Enable the deployment to the management account as well
   enable_management_account = true
-  ## The name of the cloudformation stack 
+  ## The name of the cloudformation stack
   name = "LZA-IAM-DefaultBoundary-Sandbox"
-  ## The region to deploy the cloudformation template
-  region = "us-west-2"
-  ## The tags to apply to the cloudformation stack 
+  ## The tags to apply to the cloudformation stack
   tags = {}
   ## The cloudformation template to deploy 
   template = file("assets/default-boundary.yml")

--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,7 @@ resource "aws_cloudformation_stack_set" "boundary" {
 
 ## Deploy the permissive boundary to the organizational root
 resource "aws_cloudformation_stack_set_instance" "root" {
+  region = var.region
   deployment_targets {
     organizational_unit_ids = local.organizational_units
   }

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,13 @@
     "config:recommended",
     ":semanticCommitTypeAll(chore)",
     "schedule:earlyMondays"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "pinDigests": true
+    }
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -38,6 +38,11 @@ variable "parameters" {
   default     = {}
 }
 
+variable "region" {
+  description = "The region to deploy the cloudformation template"
+  type        = string
+}
+
 variable "tags" {
   description = "The tags to apply to the cloudformation stack"
   type        = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -38,11 +38,6 @@ variable "parameters" {
   default     = {}
 }
 
-variable "region" {
-  description = "The region to deploy the cloudformation template"
-  type        = string
-}
-
 variable "tags" {
   description = "The tags to apply to the cloudformation stack"
   type        = map(string)


### PR DESCRIPTION
Adds `pinDigests: true` for the `github-actions` Renovate manager so reusable workflow references to `appvia/appvia-cicd-workflows` are pinned to immutable commit SHAs. Renovate will raise a follow-up PR to pin existing refs. Part of SA-689.